### PR TITLE
Bug fix: fixed className warning in popupmodal component

### DIFF
--- a/src/components/PopUpModal/PopUpModal.jsx
+++ b/src/components/PopUpModal/PopUpModal.jsx
@@ -1,6 +1,7 @@
 import './PopUpModal.scss';
 import Button from '../Button/Button';
 
+//to be passed in to the style prop of Modal component
 const PopUpStyle = {
     overlay: {
         position: 'fixed',
@@ -19,7 +20,6 @@ const PopUpStyle = {
         width: '500px',
         height: '50%',
         border: 'none',
-        // background: 'rgba(100, 100, 100, 1)',
         overflow: 'auto',
         WebkitOverflowScrolling: 'touch',
         borderRadius: '24px',
@@ -32,8 +32,8 @@ const PopUpStyle = {
 const PopUpModal = ({ title, closeButtonAction, closeButtonName, children }) => {
     return (
         <>
-            <div class="modal">
-                <div class="content">
+            <div className="modal">
+                <div className="content">
                     <div className="popUpModal">
                         <div className="header">
                             <div className="bodyTitleOutput">


### PR DESCRIPTION
JIRA Ticket link: [PC-90](https://makeitmvp.atlassian.net/browse/PC-90)

## Type of change

- [x] Bug fix
- [] New feature
- [ ] Refactoring

## Description

- Changes made?
changed div with class to className

- Reason for changes?
-react was throwing warning 
- Behavior before?
- Behavior after?
- How did you test?

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested the new feature and found it to be working as expected.
- [x] All commits in this PR are related to the issue.
- [x] Base branch for this PR is set to `develop`.
- [x] JIRA ticket # and my initials are noted in this PR's name (format example: #57-EB Add Pull Request template)

**Reminder**: every PR needs at least 1 peer approval before merging to the `develop` branch. Once a main ticket has been completed, along with all subtasks, associated code can be merged to `main`.


[PC-90]: https://makeitmvp.atlassian.net/browse/PC-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ